### PR TITLE
Fix relative import in TkinterGUISample for direct script execution

### DIFF
--- a/samples/TkinterGUISample/main.py
+++ b/samples/TkinterGUISample/main.py
@@ -4,7 +4,7 @@
 import tkinter as tk
 from tkinter import ttk, scrolledtext
 from ctrader_open_api import Client, TcpProtocol, EndPoints
-from .strategies import StrategyManager # Import StrategyManager
+from strategies import StrategyManager # Import StrategyManager
 
 from twisted.internet import reactor, tksupport
 


### PR DESCRIPTION
Changed 'from .strategies import StrategyManager' to 'from strategies import StrategyManager' in samples/TkinterGUISample/main.py.

This allows main.py to be run as a standalone script from its own directory without an ImportError, which is a common way users might run sample applications. This commit is additive to the previous enhancements.